### PR TITLE
Expose emqtt statistics (statsd)

### DIFF
--- a/src/emqttd_ws.erl
+++ b/src/emqttd_ws.erl
@@ -21,6 +21,7 @@
 -include("emqttd_protocol.hrl").
 
 -import(proplists, [get_value/3]).
+-import(emqt_statsd, [get_metrics/0]).
 
 -export([handle_request/1, ws_loop/3]).
 
@@ -31,7 +32,6 @@
               lager:Level("WsClient(~s): " ++ Format,
                           [esockd_net:format(State#wsocket_state.peername) | Args])).
 
-
 handle_request(Req) ->
     handle_request(Req:get(method), Req:get(path), Req).
 
@@ -40,7 +40,8 @@ handle_request(Req) ->
 %%--------------------------------------------------------------------
 
 handle_request('GET', "/metrics", Req) ->
-    Req:respond({200, [], <<"Metrics!">>});
+    lager:info(get_metrics()),
+    Req:respond({200, [get_metrics()], <<"Metrics!">>});
 
 handle_request('GET', "/ready", Req) ->
     lager:debug("WebSocket Ready Check from: ~s", [Req:get(peer)]),

--- a/src/emqttd_ws.erl
+++ b/src/emqttd_ws.erl
@@ -40,15 +40,16 @@ handle_request(Req) ->
 %%--------------------------------------------------------------------
 
 handle_request('GET', "/metrics", Req) ->
-    lager:debug("Metrics Pull Request from");
+    lager:debug("Metrics Pull Request from"),
+    Req:respond({200, [], <<"Metrics!">>});
 
 handle_request('GET', "/ready", Req) ->
-		lager:debug("WebSocket Ready Check from: ~s", [Req:get(peer)]),
-		Req:respond({200, [], <<"I'm ready!">>});
+    lager:debug("WebSocket Ready Check from: ~s", [Req:get(peer)]),
+    Req:respond({200, [], <<"I'm ready!">>});
 
 handle_request('GET', "/live", Req) ->
-		lager:debug("WebSocket Live Check from: ~s", [Req:get(peer)]),
-		Req:respond({200, [], <<"I'm alive!">>});
+    lager:debug("WebSocket Live Check from: ~s", [Req:get(peer)]),
+    Req:respond({200, [], <<"I'm alive!">>});
 
 handle_request('GET', "/mqtt", Req) ->
     lager:debug("WebSocket Connection from: ~s", [Req:get(peer)]),

--- a/src/emqttd_ws.erl
+++ b/src/emqttd_ws.erl
@@ -40,7 +40,7 @@ handle_request(Req) ->
 %%--------------------------------------------------------------------
 
 handle_request('GET', "/metrics", Req) ->
-    lager:debug("Metrics Pull Request"),
+    lager:debug("Metrics Pull Request from: ~s", [Req:get(peer)]),
     Req:respond({200, [{"Content-Type", "text/plain"}], get_metrics()});
 
 handle_request('GET', "/ready", Req) ->

--- a/src/emqttd_ws.erl
+++ b/src/emqttd_ws.erl
@@ -40,7 +40,6 @@ handle_request(Req) ->
 %%--------------------------------------------------------------------
 
 handle_request('GET', "/metrics", Req) ->
-    lager:debug("Metrics Pull Request from"),
     Req:respond({200, [], <<"Metrics!">>});
 
 handle_request('GET', "/ready", Req) ->

--- a/src/emqttd_ws.erl
+++ b/src/emqttd_ws.erl
@@ -21,7 +21,7 @@
 -include("emqttd_protocol.hrl").
 
 -import(proplists, [get_value/3]).
--import(emqt_statsd, [get_metrics/0]).
+-import(emq_statsd, [get_metrics/0]).
 
 -export([handle_request/1, ws_loop/3]).
 

--- a/src/emqttd_ws.erl
+++ b/src/emqttd_ws.erl
@@ -40,8 +40,8 @@ handle_request(Req) ->
 %%--------------------------------------------------------------------
 
 handle_request('GET', "/metrics", Req) ->
-    lager:info(get_metrics()),
-    Req:respond({200, [get_metrics()], <<"Metrics!">>});
+    lager:debug("Metrics Pull Request"),
+    Req:respond({200, [{"Content-Type", "text/plain"}], get_metrics()});
 
 handle_request('GET', "/ready", Req) ->
     lager:debug("WebSocket Ready Check from: ~s", [Req:get(peer)]),

--- a/src/emqttd_ws.erl
+++ b/src/emqttd_ws.erl
@@ -39,6 +39,9 @@ handle_request(Req) ->
 %% MQTT Over WebSocket
 %%--------------------------------------------------------------------
 
+handle_request('GET', "/metrics", Req) ->
+    lager:debug("Metrics Pull Request from");
+
 handle_request('GET', "/ready", Req) ->
 		lager:debug("WebSocket Ready Check from: ~s", [Req:get(peer)]),
 		Req:respond({200, [], <<"I'm ready!">>});


### PR DESCRIPTION
As part of [PLATS-267](https://talkdesk.atlassian.net/browse/PLATS-277), we have exposed the /metrics endpoint to be scraped by the prometheus server.